### PR TITLE
fix: supabase sync error handling

### DIFF
--- a/src/api/supabase/syncArticles.ts
+++ b/src/api/supabase/syncArticles.ts
@@ -45,13 +45,13 @@ async function syncArticlesWithSupabase({
                 .eq('username', author.username);
 
             if (authorError) {
-                console.error('Error fetching author:', authorError);
+                console.error('Error fetching author from syncArticlesWithSupabase:', authorError);
                 continue;
             }
 
             let authorId;
 
-            // 저자가 이미 존재하는 경우 중복 삽입을 방지하기 위해 계속 진행
+            // 4. author 데이터가 없을 시 Supabase의 author 테이블 데이터 삽입
             if (existingAuthors && existingAuthors.length > 0) {
                 authorId = existingAuthors[0].id; // 첫 번째 저자의 ID 사용
 

--- a/src/api/supabase/syncComments.ts
+++ b/src/api/supabase/syncComments.ts
@@ -5,7 +5,7 @@ async function syncCommentsWithSupabase(slug: string) {
     try {
         // 1. Real World API fetch
         const { comments } = await fetchComments(slug);
-        console.log('Fetched Comments from API:', comments);
+        console.log('Fetched Comments from API:', comments.length);
 
         for (const comment of comments) {
             const { body, createdAt, updatedAt, author } = comment;
@@ -65,7 +65,7 @@ async function syncCommentsWithSupabase(slug: string) {
             if (fetchError) {
                 console.error('Error fetching comments after insert:', fetchError);
             } else if (process.env.NODE_ENV !== 'production') {
-                console.log('Comments synchronized successfully! :', insertedComments);
+                console.log('Comments synchronized successfully! : ', insertedComments.length);
             }
         }
     } catch (error) {

--- a/src/api/supabase/syncDetails.ts
+++ b/src/api/supabase/syncDetails.ts
@@ -10,35 +10,54 @@ async function syncDetailsWithSupabase(slug: string) {
         const { title, description, body, tagList, createdAt, updatedAt, favorited, favoritesCount, author } = article;
 
         // 2. Supabase 테이블에서 데이터 확인
-        const { data: existingArticle, error: articleError } = await supabase
+        const { data: existingArticles, error: articleError } = await supabase
             .from('article_details')
             .select('id, slug')
-            .eq('slug', slug)
-            .maybeSingle();
-
-        if (existingArticle) {
-            if (process.env.NODE_ENV !== 'production') {
-                console.log(`Article with slug ${slug} already exists, skipping insertion.`);
-            }
-            return;
-        }
+            .eq('slug', slug);
 
         if (articleError) {
             console.error('Error fetching existing article from Supabase:', articleError);
             return;
         }
 
+        if (existingArticles.length > 1) {
+            console.warn(`Warning: Multiple entries found for the same Article: "${slug}", skipping insertion.`);
+            return;
+        }
+
+        if (existingArticles.length === 1) {
+            if (process.env.NODE_ENV !== 'production') {
+                console.log(`Article with slug ${slug} already exists, skipping insertion.`);
+            }
+            return;
+        }
+
+        if (process.env.NODE_ENV !== 'production') {
+            console.log(`Article "${slug}" data does not exist in Supabase. Proceeding with insertion...`);
+        }
+
         // 3. Supabase의 author 테이블에서 데이터 확인
-        const { data: existingAuthor, error: authorError } = await supabase
+        const { data: existingAuthors, error: authorError } = await supabase
             .from('author')
             .select('id, username')
-            .eq('username', author.username)
-            .maybeSingle(); // maybeSingle 사용하여 중복된 작가 확인
+            .eq('username', author.username);
 
-        let authorId = existingAuthor ? existingAuthor.id : null;
+        if (authorError) {
+            console.error('Error fetching author From syncDetailsWithSupabase:', authorError);
+            return;
+        }
 
-        // 4. 중복 없을 시 Supabase의 author 테이블 데이터 삽입
-        if (!existingAuthor && !authorError) {
+        let authorId;
+
+        // 4. author 데이터가 없을 시 Supabase의 author 테이블 데이터 삽입
+        if (existingAuthors && existingAuthors.length > 0) {
+            authorId = existingAuthors[0].id; // 첫 번째 저자의 ID 사용
+
+            if (process.env.NODE_ENV !== 'production') {
+                console.log(`Author with username ${author.username} already exists.`);
+            }
+        } else {
+            // 저자가 존재하지 않으면 새로운 저자를 삽입
             const { data: insertedAuthor, error: authorInsertError } = await supabase
                 .from('author')
                 .insert({
@@ -55,44 +74,46 @@ async function syncDetailsWithSupabase(slug: string) {
                 return;
             }
 
-            authorId = insertedAuthor.id;
-
-            if (process.env.NODE_ENV !== 'production') {
-                console.log(`Author ${author.username} inserted successfully.`);
-            }
+            authorId = insertedAuthor?.id;
         }
 
         // 5. 중복 없을 시 article_details 테이블에 데이터 삽입
-        if (!existingArticle) {
-            const { error: articleInsertError } = await supabase.from('article_details').insert({
-                slug,
-                title,
-                description,
-                body,
-                tag_list: tagList,
-                created_at: createdAt,
-                updated_at: updatedAt,
-                favorited,
-                favorites_count: favoritesCount,
-                author_id: authorId,
-            });
+        const { error } = await supabase.from('article_details').insert({
+            slug,
+            title,
+            description,
+            body,
+            tag_list: tagList,
+            created_at: createdAt,
+            updated_at: updatedAt,
+            favorited,
+            favorites_count: favoritesCount,
+            author_id: authorId,
+        });
 
-            if (articleInsertError) {
-                console.error('Article insertion failed:', articleInsertError);
-                return;
+        if (error) {
+            if (error.code === '23505') {
+                console.warn('Warning: Article data insertion failed due to existing data.');
+            } else {
+                console.error('Error Article insertion failed:', error);
             }
-        } else {
-            if (process.env.NODE_ENV !== 'production') {
-                console.log(`Article with slug ${slug} already exists, skipping insertion.`);
-            }
+            return;
+        } else if (process.env.NODE_ENV !== 'production') {
+            console.log('Article Details insertion successfully!');
         }
 
         // 6. Supabase 테이블에 제대로 삽입되었는지 바로 확인
-        const { data: insertedDetails, error: fetchError } = await supabase.from('article_details').select('*');
+        const { data: insertedDetail, error: fetchError } = await supabase
+            .from('article_details')
+            .select('id, slug')
+            .eq('slug', slug)
+            .single();
+
         if (fetchError) {
             console.error('Error fetching Article Details after insert:', fetchError);
+            return;
         } else if (process.env.NODE_ENV !== 'production') {
-            console.log('Article Details synchronized successfully! : ', insertedDetails);
+            console.log('Article Details synchronized successfully!! : ', insertedDetail);
         }
     } catch (error) {
         console.error('Error synchronizing Article Details:', error);

--- a/src/api/supabase/syncTags.ts
+++ b/src/api/supabase/syncTags.ts
@@ -69,22 +69,24 @@ async function syncTagListWithSupabase() {
 }
 
 async function fetchTagListFromSupabase(): Promise<{ tags: Article['tagList'] }> {
-    const { data: tags, error } = await supabase.from('tags').select('"tag"');
-    // 쌍따옴표(대소문자 구분 목적)를 제거한 값 select('tag')을 넣으면 UI 화면에 중복된 tag가 노출된다
+    const { data: tagsData, error } = await supabase.from('tags').select('tag');
 
     if (error) {
         throw new Error(`Failed to fetch tags: ${error.message}`);
     }
 
     if (process.env.NODE_ENV !== 'production') {
-        console.log('Fetched tags from Supabase:', tags);
+        console.log('Fetched tags from Supabase:', tagsData);
     }
 
-    if (!tags || tags.length === 0) {
+    if (!tagsData || tagsData.length === 0) {
         return { tags: [] };
     }
 
-    return { tags: tags.map(tagRow => tagRow.tag) };
+    const tags: string[] = tagsData.map(tagRow => tagRow.tag);
+    const uniqueTags = [...new Set(tags)];
+
+    return { tags: uniqueTags };
 }
 
 export { syncTagListWithSupabase, fetchTagListFromSupabase };

--- a/src/api/supabase/syncTags.ts
+++ b/src/api/supabase/syncTags.ts
@@ -9,23 +9,27 @@ async function syncTagListWithSupabase() {
 
         for (const tag of tags) {
             // 2. Supabase 테이블에서 데이터 확인
-            const { data: existingTag, error: tagError } = await supabase
-                .from('tags')
-                .select('id, tag')
-                .eq('tag', tag)
-                .maybeSingle();
+            const { data: existingTag, error: tagError } = await supabase.from('tags').select('id, tag').eq('tag', tag);
 
-            if (existingTag) {
-                if (process.env.NODE_ENV !== 'production') {
-                    console.log(`Tag ${tag} already exists, skipping insertion.`);
-                }
-
+            if (tagError) {
+                console.error(`Error fetching existing Tag "${tag}" from Supabase:`, tagError);
                 continue;
             }
 
-            if (tagError) {
-                console.error('Error fetching existing tag from Supabase:', tagError);
+            if (existingTag.length > 1) {
+                console.warn(`Warning: Multiple entries found for the same Tag: "${tag}", skipping insertion.`);
                 continue;
+            }
+
+            if (existingTag.length === 1) {
+                if (process.env.NODE_ENV !== 'production') {
+                    console.log(`Tag "${tag}" already exists, skipping insertion.`);
+                }
+                continue;
+            }
+
+            if (process.env.NODE_ENV !== 'production') {
+                console.log(`Tag "${tag}" data does not exist in Supabase. Proceeding with insertion...`);
             }
 
             // 3. 중복 없을 시 Supabase 테이블에 데이터 삽입
@@ -36,20 +40,31 @@ async function syncTagListWithSupabase() {
 
             if (error) {
                 console.error('Error insert tag: ', error);
+                if (error.code === '23505') {
+                    console.warn('Warning: Profile data insertion failed due to existing data.');
+                } else {
+                    console.error(`Error Tag "${tag}" insertion failed:`, error);
+                }
                 continue;
+            } else if (process.env.NODE_ENV !== 'production') {
+                console.log(`Tag "${tag}" inserted successfully!`);
             }
 
             // 4. Supabase 테이블에 제대로 삽입되었는지 바로 확인
-            const { data: insertedTags, error: fetchError } = await supabase.from('tags').select('*');
+            const { data: insertedTag, error: fetchError } = await supabase
+                .from('tags')
+                .select('id, tag')
+                .eq('tag', tag)
+                .single();
 
             if (fetchError) {
                 console.error('Error fetching tags after insert:', fetchError);
             } else if (process.env.NODE_ENV !== 'production') {
-                console.log('Tags synchronized successfully! :', insertedTags);
+                console.log('Tags synchronized successfully! :', insertedTag);
             }
         }
     } catch (error) {
-        console.error('Error synchronizing tags:', error);
+        console.error('Error synchronizing Tags:', error);
     }
 }
 

--- a/src/app/article/[slug]/page.tsx
+++ b/src/app/article/[slug]/page.tsx
@@ -29,7 +29,7 @@ export default async function ArticleDetails({ params }: { params: { slug: strin
 
     await syncCommentsWithSupabase(params.slug);
     const { comments } = await fetchCommentsFromSupabase(params.slug);
-    console.log('===================== Fetch comments data: ', comments);
+    // console.log('===================== Fetch comments data: ', comments);
 
     return (
         <div className="article-page">

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es5",
+        "target": "es2015",
         "lib": ["dom", "dom.iterable", "esnext", "ES2021.String"],
         "allowJs": true,
         "skipLibCheck": true,


### PR DESCRIPTION
✅ 중복되는 tag 제거

✅ 리얼월드 API에서 받은 첫 데이터의 경우 Supabase 데이터에 없으므로 Supabase 테이블 조회시 오류가 안나도록 수정 
(`single()` 또는` maybesingle()` 메서드는 데이터 조회시 값이 없으면 error 객체를 반환하므로 제거)

✅ 리얼월드 API 데이터와 일치하는 supabase 조회시 중복이 여러개 있을 경우 에러(console.error)가 아닌 경고(console.warn)로 수정
(잘못쌓인 중복 데이터는 supabase에서 제거하도록 경고)

✅ sync 각 단계별 console.log 일관성 있게 추가 및 수정